### PR TITLE
strip_leading_dir is DEPRECATED in ark 0.9.0 - use strip_components i…

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -26,7 +26,6 @@ ark 'terraform' do
   checksum node['terraform']['checksum']
   has_binaries ['terraform']
   append_env_path false
-  strip_leading_dir false
   strip_components 0
 
   if platform_family?('windows')


### PR DESCRIPTION
…nstead
